### PR TITLE
Add first round results tracking

### DIFF
--- a/tournament.html
+++ b/tournament.html
@@ -63,14 +63,18 @@ h2 {
 <button id="randomize">Randomize Pairings</button>
 <button id="startRound" class="success">Start First Round</button>
 </section>
-<h2>Pairings</h2>
+<h2>Pairings of the first round</h2>
 <section class="card">
 <ul id="pairingsList"></ul>
 </section>
+<h2>Results</h2>
+<section class="card" id="resultsSection"></section>
 <script>
 const PARTICIPANTS_KEY = 'participants';
 const STARTED_KEY = 'tournamentStarted';
 const PAIRINGS_KEY = 'pairings';
+const RESULTS_KEY = 'round1Results';
+const SCORES_KEY = 'round1Scores';
 
 function loadParticipants() {
   const data = localStorage.getItem(PARTICIPANTS_KEY);
@@ -80,6 +84,24 @@ function loadParticipants() {
 
 function savePairings(pairings) {
   localStorage.setItem(PAIRINGS_KEY, JSON.stringify(pairings));
+}
+
+function loadResults() {
+  const data = localStorage.getItem(RESULTS_KEY);
+  return data ? JSON.parse(data) : {};
+}
+
+function saveResults(results) {
+  localStorage.setItem(RESULTS_KEY, JSON.stringify(results));
+}
+
+function loadScores() {
+  const data = localStorage.getItem(SCORES_KEY);
+  return data ? JSON.parse(data) : {};
+}
+
+function saveScores(scores) {
+  localStorage.setItem(SCORES_KEY, JSON.stringify(scores));
 }
 
 function getStarted() {
@@ -100,7 +122,7 @@ function randomizePairingsList(participants) {
   for (let i = 0; i < shuffled.length; i += 2) {
     const p1 = shuffled[i];
     const p2 = shuffled[i + 1] || { name: 'BYE' };
-    pairings.push(`${p1.name} vs ${p2.name}`);
+    pairings.push({ p1: p1.name, p2: p2.name });
   }
   return pairings;
 }
@@ -108,11 +130,63 @@ function randomizePairingsList(participants) {
 function displayPairings(pairings) {
   const list = document.getElementById('pairingsList');
   list.innerHTML = '';
-  pairings.forEach(p => {
+  pairings.forEach((p, idx) => {
     const li = document.createElement('li');
-    li.textContent = p;
+    li.textContent = `${idx + 1}. ${p.p1} vs ${p.p2}`;
     list.appendChild(li);
   });
+}
+
+function displayResults(pairings, results) {
+  const container = document.getElementById('resultsSection');
+  container.innerHTML = '';
+  pairings.forEach((p, idx) => {
+    const div = document.createElement('div');
+    const label = document.createElement('span');
+    label.textContent = `Match ${idx + 1}: `;
+    div.appendChild(label);
+
+    const b1 = document.createElement('button');
+    b1.textContent = p.p1;
+    const b2 = document.createElement('button');
+    b2.textContent = p.p2;
+    const draw = document.createElement('button');
+    draw.textContent = 'Draw';
+
+    b1.addEventListener('click', () => recordResult(idx, 'p1'));
+    b2.addEventListener('click', () => recordResult(idx, 'p2'));
+    draw.addEventListener('click', () => recordResult(idx, 'draw'));
+
+    div.appendChild(b1);
+    div.appendChild(b2);
+    div.appendChild(draw);
+    container.appendChild(div);
+  });
+}
+
+function updateScores() {
+  const scores = {};
+  pairings.forEach((p, idx) => {
+    if (!scores[p.p1]) scores[p.p1] = 0;
+    if (!scores[p.p2]) scores[p.p2] = 0;
+    const r = results[idx];
+    if (r === 'p1') {
+      scores[p.p1] += 3;
+    } else if (r === 'p2') {
+      scores[p.p2] += 3;
+    } else if (r === 'draw') {
+      scores[p.p1] += 1;
+      scores[p.p2] += 1;
+    }
+  });
+  saveScores(scores);
+}
+
+function recordResult(index, outcome) {
+  results[index] = outcome;
+  saveResults(results);
+  updateScores();
+  displayResults(pairings, results);
 }
 
 function startTimer(duration) {
@@ -136,15 +210,25 @@ function formatTime(seconds) {
 
 const participants = loadParticipants();
 let pairings = [];
+let results = {};
 
 function initialize() {
   pairings = localStorage.getItem(PAIRINGS_KEY);
   if (pairings) {
     try { pairings = JSON.parse(pairings); } catch (e) { pairings = []; }
+    if (pairings.length && typeof pairings[0] === 'string') {
+      pairings = pairings.map(str => {
+        const parts = str.split(' vs ');
+        return { p1: parts[0], p2: parts[1] || 'BYE' };
+      });
+      savePairings(pairings);
+    }
   } else {
     pairings = [];
   }
+  results = loadResults();
   displayPairings(pairings);
+  displayResults(pairings, results);
   if (getStarted()) {
     document.getElementById('randomize').disabled = true;
   }
@@ -154,10 +238,14 @@ initialize();
 
 document.getElementById('newTournament').addEventListener('click', () => {
   localStorage.removeItem(PAIRINGS_KEY);
+  localStorage.removeItem(RESULTS_KEY);
+  localStorage.removeItem(SCORES_KEY);
   setStarted(false);
   pairings = randomizePairingsList(participants);
   savePairings(pairings);
+  results = {};
   displayPairings(pairings);
+  displayResults(pairings, results);
   document.getElementById('randomize').disabled = false;
 });
 
@@ -165,7 +253,11 @@ document.getElementById('randomize').addEventListener('click', () => {
   if (getStarted()) return;
   pairings = randomizePairingsList(participants);
   savePairings(pairings);
+  results = {};
+  saveResults(results);
+  saveScores({});
   displayPairings(pairings);
+  displayResults(pairings, results);
 });
 
 document.getElementById('startRound').addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- add results section below pairings
- show pairing index numbers
- store match results in localStorage
- track points for each player in round 1
- convert old pairings data if present
- update display when pairings change

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68409e22aad883279d5943eb6a236cf9