### PR TITLE
Implement Yugioh tie‑breakers

### DIFF
--- a/tournament.html
+++ b/tournament.html
@@ -51,7 +51,7 @@ h2 {
  }
 
  #roundClock {
-  font-size: 2em;
+  font-size: 3em;
   text-align: center;
   margin-bottom: 10px;
  }
@@ -99,7 +99,7 @@ h2 {
 <h2>Tabla de Posiciones</h2>
 <table id="scoreTable">
 <thead>
-<tr><th>#</th><th>Nombre</th><th>Puntos</th></tr>
+<tr><th>#</th><th>Nombre</th><th>Puntos</th><th>OMW%</th><th>MW%</th></tr>
 </thead>
 <tbody id="scoreTableBody"></tbody>
 </table>
@@ -171,7 +171,14 @@ function randomizePairingsList(participants) {
 }
 
 function swissPairings() {
-  const players = participants.map(p => p.name).sort((a, b) => (scores[b] || 0) - (scores[a] || 0));
+  const players = participants.map(p => p.name).sort((a, b) => {
+    const sb = scores[b] || { points: 0, omwp: 0, mwp: 0 };
+    const sa = scores[a] || { points: 0, omwp: 0, mwp: 0 };
+    if (sb.points !== sa.points) return sb.points - sa.points;
+    if (sb.omwp !== sa.omwp) return sb.omwp - sa.omwp;
+    if (sb.mwp !== sa.mwp) return sb.mwp - sa.mwp;
+    return a.localeCompare(b);
+  });
   const out = [];
   for (let i = 0; i < players.length; i += 2) {
     const p1 = players[i];
@@ -230,40 +237,94 @@ function displayResults(roundPairings, roundResults, round) {
 function displayScores(scores) {
   const body = document.getElementById('scoreTableBody');
   body.innerHTML = '';
-  const entries = Object.entries(scores).sort((a, b) => b[1] - a[1]);
-  entries.forEach(([name, pts], idx) => {
+  const entries = Object.entries(scores).sort((a, b) => {
+    if (b[1].points !== a[1].points) return b[1].points - a[1].points;
+    if (b[1].omwp !== a[1].omwp) return b[1].omwp - a[1].omwp;
+    if (b[1].mwp !== a[1].mwp) return b[1].mwp - a[1].mwp;
+    return a[0].localeCompare(b[0]);
+  });
+  entries.forEach(([name, s], idx) => {
     const tr = document.createElement('tr');
     const pos = document.createElement('td');
     pos.textContent = idx + 1;
     const nm = document.createElement('td');
     nm.textContent = name;
     const sc = document.createElement('td');
-    sc.textContent = pts;
+    sc.textContent = s.points;
+    const omw = document.createElement('td');
+    omw.textContent = (s.omwp * 100).toFixed(2) + '%';
+    const mw = document.createElement('td');
+    mw.textContent = (s.mwp * 100).toFixed(2) + '%';
     tr.appendChild(pos);
     tr.appendChild(nm);
     tr.appendChild(sc);
+    tr.appendChild(omw);
+    tr.appendChild(mw);
     body.appendChild(tr);
   });
 }
 
-function updateScores() {
-  scores = {};
+function calculateStandings() {
+  const stats = {};
+  participants.forEach(p => {
+    stats[p.name] = { points: 0, wins: 0, draws: 0, matches: 0, opponents: [] };
+  });
   for (let r = 1; r <= currentRound; r++) {
     const pr = pairings[r] || [];
     pr.forEach((p, idx) => {
-      if (!scores[p.p1]) scores[p.p1] = 0;
-      if (!scores[p.p2]) scores[p.p2] = 0;
       const res = (results[r] || {})[idx];
+      if (!res) return;
+      const { p1, p2 } = p;
+      if (p2 !== 'BYE') {
+        stats[p1].opponents.push(p2);
+        stats[p2].opponents.push(p1);
+      }
+      if (p2 === 'BYE') {
+        stats[p1].matches += 1;
+        if (res === 'p1') {
+          stats[p1].points += 3;
+          stats[p1].wins += 1;
+        } else if (res === 'draw') {
+          stats[p1].points += 1;
+          stats[p1].draws += 1;
+        }
+        return;
+      }
+      stats[p1].matches += 1;
+      stats[p2].matches += 1;
       if (res === 'p1') {
-        scores[p.p1] += 3;
+        stats[p1].points += 3;
+        stats[p1].wins += 1;
       } else if (res === 'p2') {
-        scores[p.p2] += 3;
+        stats[p2].points += 3;
+        stats[p2].wins += 1;
       } else if (res === 'draw') {
-        scores[p.p1] += 1;
-        scores[p.p2] += 1;
+        stats[p1].points += 1;
+        stats[p2].points += 1;
+        stats[p1].draws += 1;
+        stats[p2].draws += 1;
       }
     });
   }
+  for (const n in stats) {
+    const s = stats[n];
+    s.mwp = s.matches ? (s.wins + 0.5 * s.draws) / s.matches : 0;
+  }
+  for (const n in stats) {
+    const opps = stats[n].opponents;
+    let total = 0;
+    opps.forEach(o => {
+      let m = stats[o] ? stats[o].mwp : 0;
+      if (m < 1 / 3) m = 1 / 3;
+      total += m;
+    });
+    stats[n].omwp = opps.length ? total / opps.length : 0;
+  }
+  return stats;
+}
+
+function updateScores() {
+  scores = calculateStandings();
   displayScores(scores);
 }
 
@@ -345,7 +406,7 @@ function initialize() {
   if (!getSimulated()) {
     document.getElementById('newTournament').disabled = true;
   }
-  displayScores({});
+  updateScores();
 }
 
 initialize();
@@ -387,7 +448,7 @@ document.getElementById('newTournament').addEventListener('click', () => {
   clearInterval(tournamentInterval);
   tournamentStartTime = null;
   document.getElementById('tournamentTime').textContent = 'Tournament time: 00:00';
-  displayScores(scores);
+  updateScores();
   createRoundSections();
   document.getElementById('startRound').disabled = false;
   document.getElementById('startRound').textContent = 'Start Round 1';


### PR DESCRIPTION
## Summary
- enlarge the round clock for better visibility
- expand the standings table with Opponent Match Win % and Match Win %
- compute standings using Yugioh tie-breakers
- seed new tournaments with initial standings

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840a948af588327997471d6bf37d08a