### PR TITLE
Fix bottom link placement

### DIFF
--- a/tournament.html
+++ b/tournament.html
@@ -660,8 +660,8 @@ function checkRoundCompletion(round) {
     }
   }
 }
-</script>
-<p><a href="index.html">Back to Home</a></p>
-</div>
-</body>
-</html>
+  </script>
+  </div>
+  <p style="text-align:center;"><a href="index.html">Back to Home</a></p>
+  </body>
+  </html>


### PR DESCRIPTION
## Summary
- keep tournament page link at the bottom by moving it out of the flex container

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842fc7877f083278b14263b7b4477eb